### PR TITLE
Message responses in the configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,23 @@ If the file doesn't exist, it will create one, but bear in mind that
 it will not run without either a valid bot token in the `DISCORD_TOKEN` environment variable,
 or the `discord_token` field in the config file.
 
-A standard `config.toml` file looks like this:
+An example `config.toml` file looks like this:
 ```toml
 text_detect_cooldown = 5
 discord_token = "your_token_here"
+
+[[responses]]
+[responses.Text]
+name = "example"
+pattern = "ex(ample)?"
+content = "Hello, world!"
 ```
 Note that the text detection cooldown is
 specified in minutes.
+
+Message responses are also specified in the configuration file,
+in a `[[responses]]` array. The four possible types of response
+are currently `Text`, `RandomText`, `Image`, and `TextAndImage`.
+Fields that are common to all response types are the `name` and `pattern`
+fields, while `content` is used for text content (an array of text in the case of `RandomText`),
+and `path` is used for image content.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 use std::sync::{Mutex, MutexGuard};
 
 use chrono::Duration;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 /// In minutes
@@ -9,6 +10,7 @@ const DEFAULT_TEXT_DETECT_COOLDOWN: i64 = 5;
 pub struct Config {
     text_detect_cooldown: Mutex<Duration>,
     discord_token: String,
+    responses: Mutex<Vec<MessageResponse>>
 }
 
 impl Config {
@@ -32,12 +34,11 @@ impl Config {
             None => std::env::var("DISCORD_TOKEN").expect("missing DISCORD_TOKEN"),
         };
 
-        // this is just a shortcut to save the file lol
         let config = Config {
             text_detect_cooldown: Mutex::new(text_detect_cooldown),
             discord_token,
+            responses: Mutex::new(config_builder.responses)
         };
-        config.update_cooldown(text_detect_cooldown);
 
         config
     }
@@ -47,13 +48,23 @@ impl Config {
         let mut text_detect_cooldown = self.lock_cooldown();
         *text_detect_cooldown = cooldown;
 
-        let config_builder = ConfigBuilder {
-            text_detect_cooldown: Some(cooldown.num_minutes()),
-            discord_token: Some(self.discord_token.clone()),
-        };
-        let toml = toml::to_string(&config_builder).unwrap();
+        self.save();
+    }
 
-        std::fs::write("./config.toml", toml).expect("Could not write to config.toml");
+    /// Adds a response to the config.toml file and the config.
+    pub fn add_response(&self, response: MessageResponse) {
+        let mut responses = self.responses.lock().unwrap();
+        responses.push(response);
+
+        self.save();
+    }
+
+    /// Removes a response from the config.toml file and the config.
+    pub fn remove_response(&self, name: String) {
+        let mut responses = self.responses.lock().unwrap();
+        *responses = responses.iter().filter(|response| response.get_name() != name).cloned().collect();
+
+        self.save();
     }
 
     /// Locks and returns the text detect cooldown.
@@ -67,8 +78,31 @@ impl Config {
         text_detect_cooldown
     }
 
+    pub fn lock_responses(&self) -> MutexGuard<Vec<MessageResponse>> {
+        let responses = self.responses.lock().unwrap();
+
+        responses
+    }
+
+    pub fn get_response(&self, name: String) -> MessageResponse {
+        self.responses.lock().unwrap().iter()
+            .find(|response| response.get_name() == name)
+            .unwrap().clone()
+    }
+
     pub fn get_token(&self) -> String {
         self.discord_token.clone()
+    }
+
+    pub fn save(&self) {
+        let config_builder = ConfigBuilder {
+            text_detect_cooldown: Some(self.lock_cooldown().num_minutes()),
+            discord_token: Some(self.discord_token.clone()),
+            responses: self.responses.lock().unwrap().clone()
+        };
+        let toml = toml::to_string(&config_builder).unwrap();
+
+        std::fs::write("./config.toml", toml).expect("Could not write to config.toml");
     }
 }
 
@@ -76,6 +110,7 @@ impl Config {
 struct ConfigBuilder {
     text_detect_cooldown: Option<i64>,
     discord_token: Option<String>,
+    responses: Vec<MessageResponse>
 }
 
 impl ConfigBuilder {
@@ -83,6 +118,35 @@ impl ConfigBuilder {
         ConfigBuilder {
             text_detect_cooldown: None,
             discord_token: None,
+            responses: Vec::new()
+        }
+    }
+}
+
+#[derive(Deserialize,Serialize,Clone)]
+pub enum MessageResponse {
+    Text{name: String, pattern: String, content: String},
+    RandomText{name: String, pattern: String, content: Vec<String>},
+    Image{name: String, pattern: String, path: String},
+    TextAndImage{name: String, pattern: String, content: String, path: String}
+}
+
+impl MessageResponse {
+    pub fn get_name(&self) -> String {
+        match self {
+            MessageResponse::Text{name, ..} => name.clone(),
+            MessageResponse::RandomText{name, ..} => name.clone(),
+            MessageResponse::TextAndImage{name, ..} => name.clone(),
+            MessageResponse::Image{name, ..} => name.clone()
+        }
+    }
+
+    pub fn get_pattern(&self) -> Regex {
+        match self {
+            MessageResponse::Text{pattern, ..} => Regex::new(pattern).unwrap(),
+            MessageResponse::RandomText{pattern, ..} => Regex::new(pattern).unwrap(),
+            MessageResponse::TextAndImage{pattern, ..} => Regex::new(pattern).unwrap(),
+            MessageResponse::Image{pattern, ..} => Regex::new(pattern).unwrap()
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,13 +34,11 @@ impl Config {
             None => std::env::var("DISCORD_TOKEN").expect("missing DISCORD_TOKEN"),
         };
 
-        let config = Config {
+        Config {
             text_detect_cooldown: Mutex::new(text_detect_cooldown),
             discord_token,
             responses: Mutex::new(config_builder.responses),
-        };
-
-        config
+        }
     }
 
     /// Updates config.toml with the new cooldown, and updates the cooldown as well

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,7 +10,7 @@ const DEFAULT_TEXT_DETECT_COOLDOWN: i64 = 5;
 pub struct Config {
     text_detect_cooldown: Mutex<Duration>,
     discord_token: String,
-    responses: Mutex<Vec<MessageResponse>>
+    responses: Mutex<Vec<MessageResponse>>,
 }
 
 impl Config {
@@ -37,7 +37,7 @@ impl Config {
         let config = Config {
             text_detect_cooldown: Mutex::new(text_detect_cooldown),
             discord_token,
-            responses: Mutex::new(config_builder.responses)
+            responses: Mutex::new(config_builder.responses),
         };
 
         config
@@ -62,7 +62,11 @@ impl Config {
     /// Removes a response from the config.toml file and the config.
     pub fn remove_response(&self, name: String) {
         let mut responses = self.responses.lock().unwrap();
-        *responses = responses.iter().filter(|response| response.get_name() != name).cloned().collect();
+        *responses = responses
+            .iter()
+            .filter(|response| response.get_name() != name)
+            .cloned()
+            .collect();
 
         self.save();
     }
@@ -85,9 +89,13 @@ impl Config {
     }
 
     pub fn get_response(&self, name: String) -> MessageResponse {
-        self.responses.lock().unwrap().iter()
+        self.responses
+            .lock()
+            .unwrap()
+            .iter()
             .find(|response| response.get_name() == name)
-            .unwrap().clone()
+            .unwrap()
+            .clone()
     }
 
     pub fn get_token(&self) -> String {
@@ -98,7 +106,7 @@ impl Config {
         let config_builder = ConfigBuilder {
             text_detect_cooldown: Some(self.lock_cooldown().num_minutes()),
             discord_token: Some(self.discord_token.clone()),
-            responses: self.responses.lock().unwrap().clone()
+            responses: self.responses.lock().unwrap().clone(),
         };
         let toml = toml::to_string(&config_builder).unwrap();
 
@@ -110,7 +118,7 @@ impl Config {
 struct ConfigBuilder {
     text_detect_cooldown: Option<i64>,
     discord_token: Option<String>,
-    responses: Vec<MessageResponse>
+    responses: Vec<MessageResponse>,
 }
 
 impl ConfigBuilder {
@@ -118,35 +126,52 @@ impl ConfigBuilder {
         ConfigBuilder {
             text_detect_cooldown: None,
             discord_token: None,
-            responses: Vec::new()
+            responses: Vec::new(),
         }
     }
 }
 
-#[derive(Deserialize,Serialize,Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 pub enum MessageResponse {
-    Text{name: String, pattern: String, content: String},
-    RandomText{name: String, pattern: String, content: Vec<String>},
-    Image{name: String, pattern: String, path: String},
-    TextAndImage{name: String, pattern: String, content: String, path: String}
+    Text {
+        name: String,
+        pattern: String,
+        content: String,
+    },
+    RandomText {
+        name: String,
+        pattern: String,
+        content: Vec<String>,
+    },
+    Image {
+        name: String,
+        pattern: String,
+        path: String,
+    },
+    TextAndImage {
+        name: String,
+        pattern: String,
+        content: String,
+        path: String,
+    },
 }
 
 impl MessageResponse {
     pub fn get_name(&self) -> String {
         match self {
-            MessageResponse::Text{name, ..} => name.clone(),
-            MessageResponse::RandomText{name, ..} => name.clone(),
-            MessageResponse::TextAndImage{name, ..} => name.clone(),
-            MessageResponse::Image{name, ..} => name.clone()
+            MessageResponse::Text { name, .. } => name.clone(),
+            MessageResponse::RandomText { name, .. } => name.clone(),
+            MessageResponse::TextAndImage { name, .. } => name.clone(),
+            MessageResponse::Image { name, .. } => name.clone(),
         }
     }
 
     pub fn get_pattern(&self) -> Regex {
         match self {
-            MessageResponse::Text{pattern, ..} => Regex::new(pattern).unwrap(),
-            MessageResponse::RandomText{pattern, ..} => Regex::new(pattern).unwrap(),
-            MessageResponse::TextAndImage{pattern, ..} => Regex::new(pattern).unwrap(),
-            MessageResponse::Image{pattern, ..} => Regex::new(pattern).unwrap()
+            MessageResponse::Text { pattern, .. } => Regex::new(pattern).unwrap(),
+            MessageResponse::RandomText { pattern, .. } => Regex::new(pattern).unwrap(),
+            MessageResponse::TextAndImage { pattern, .. } => Regex::new(pattern).unwrap(),
+            MessageResponse::Image { pattern, .. } => Regex::new(pattern).unwrap(),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,8 @@ use poise::Event;
 #[tokio::main]
 async fn main() {
     let config = Config::fetch();
+    config.save();
     let mut data = Data::init(config);
-    text_detection::register_detectors(&mut data);
     let framework = poise::Framework::builder()
         .options(poise::FrameworkOptions {
             commands: vec![

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use poise::Event;
 async fn main() {
     let config = Config::fetch();
     config.save();
-    let mut data = Data::init(config);
+    let data = Data::init(config);
     let framework = poise::Framework::builder()
         .options(poise::FrameworkOptions {
             commands: vec![

--- a/src/text_detection.rs
+++ b/src/text_detection.rs
@@ -1,44 +1,11 @@
-use crate::types::{Data, Error, MessageAttachment::*};
+use crate::types::{Data, Error};
 
 use std::sync::{Mutex, MutexGuard};
 
 use chrono::{DateTime, Duration, Utc};
 use poise::serenity_prelude as serenity;
 use poise::Event;
-use rand::prelude::*;
 use serenity::Message;
-
-pub fn register_detectors(data: &mut Data) {
-    data.register(
-        "rust",
-        r"rust",
-        |_message, _ctx| {
-            let i = random::<u8>() % 5;
-            Text(match i {
-                1 => "RUST MENTIONED :crab: :crab: :crab:",
-                2 => "<@216767618923757568>",
-                3 => "Rust is simply the best programming language. Nothing else can compare. I am naming my kids Rust and Ferris.",
-                4 => concat!("Launch the Polaris,\n", "the end doesn't scare us\n", "When will this cease?\n", "The warheads will all rust in peace!"),
-                _ => "Rust? Oh, you mean the game?"
-            })
-        }
-    );
-    data.register("tkinter", r"tkinter", |_message, _ctx| {
-        TextPlusImage("TKINTER MENTIONED", "./assets/tkinter.png")
-    });
-    data.register("arch", r"arch", |_message, _ctx| Text("I use Arch btw"));
-    data.register("goop", r"goop", |_message, _ctx| {
-        let i = random::<bool>();
-        Text(if i {
-            "https://tenor.com/view/gunge-gunged-slime-slimed-dunk-gif-21115557"
-        } else {
-            "https://tenor.com/view/goop-goop-house-jello-gif-23114313"
-        })
-    });
-    data.register("1984", r"1984", |_message, _ctx| {
-        Text("https://tenor.com/view/1984-gif-19260546")
-    });
-}
 
 pub async fn text_detection(
     ctx: &serenity::Context,
@@ -47,6 +14,9 @@ pub async fn text_detection(
     data: &Data,
     message: &Message,
 ) -> Result<(), Error> {
+    if message.is_own(ctx) {
+        return Ok(());
+    }
     if let Some(name) = data.check_should_respond(message) {
         if cooldown_checker(
             data.last_response(&name),

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,7 +6,6 @@ use std::sync::Mutex;
 use chrono::{DateTime, Utc};
 use poise::serenity_prelude as serenity;
 use poise::serenity_prelude::Message;
-use regex::Regex;
 
 pub struct Data {
     last_responses: HashMap<String, Mutex<DateTime<Utc>>>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -15,10 +15,16 @@ pub struct Data {
 
 impl Data {
     pub fn init(config: Config) -> Data {
-        let last_responses = config.lock_responses().iter()
+        let last_responses = config
+            .lock_responses()
+            .iter()
             .map(|response| {
-                (response.get_name(), Mutex::new(DateTime::<Utc>::from_timestamp(0, 0).unwrap()))
-            }).collect();
+                (
+                    response.get_name(),
+                    Mutex::new(DateTime::<Utc>::from_timestamp(0, 0).unwrap()),
+                )
+            })
+            .collect();
         Data {
             last_responses,
             config,
@@ -37,9 +43,11 @@ impl Data {
     /// If the message contents match any pattern, return the name of the response type.
     /// Otherwise, return None
     pub fn check_should_respond(&self, message: &Message) -> Option<String> {
-        self.config.lock_responses().iter().find(|response| {
-            response.get_pattern().is_match(&message.content)
-        }).map(|response| response.get_name())
+        self.config
+            .lock_responses()
+            .iter()
+            .find(|response| response.get_pattern().is_match(&message.content))
+            .map(|response| response.get_name())
     }
 
     pub fn last_response(&self, name: &String) -> &Mutex<DateTime<Utc>> {
@@ -54,37 +62,43 @@ impl Data {
     ) -> Result<(), Error> {
         let action = self.config.get_response(name.to_string());
         match action {
-            MessageResponse::Text{content, ..} => {
+            MessageResponse::Text { content, .. } => {
                 message.reply(ctx, content).await?;
-            },
-            MessageResponse::RandomText{content, ..} => {
+            }
+            MessageResponse::RandomText { content, .. } => {
                 let pick_index = rand::random::<usize>() % content.len();
                 message.reply(ctx, content[pick_index].clone()).await?;
-            },
-            MessageResponse::Image{path, ..} => {
-                message.channel_id.send_message(ctx, |m| {
-                    m.reference_message(message);
-                    m.allowed_mentions(|am| {
-                        am.replied_user(false);
-                        am
-                    });
-                    m.add_file(path.as_str());
+            }
+            MessageResponse::Image { path, .. } => {
+                message
+                    .channel_id
+                    .send_message(ctx, |m| {
+                        m.reference_message(message);
+                        m.allowed_mentions(|am| {
+                            am.replied_user(false);
+                            am
+                        });
+                        m.add_file(path.as_str());
 
-                    m
-                }).await?;
-            },
-            MessageResponse::TextAndImage{content, path, ..} => {
-                message.channel_id.send_message(ctx, |m| {
-                    m.reference_message(message);
-                    m.allowed_mentions(|am| {
-                        am.replied_user(false);
-                        am
-                    });
-                    m.content(content);
-                    m.add_file(path.as_str());
+                        m
+                    })
+                    .await?;
+            }
+            MessageResponse::TextAndImage { content, path, .. } => {
+                message
+                    .channel_id
+                    .send_message(ctx, |m| {
+                        m.reference_message(message);
+                        m.allowed_mentions(|am| {
+                            am.replied_user(false);
+                            am
+                        });
+                        m.content(content);
+                        m.add_file(path.as_str());
 
-                    m
-                }).await?;
+                        m
+                    })
+                    .await?;
             }
         }
         Ok(())


### PR DESCRIPTION
Instead of being added to a register function within the binary, text responses are now loaded from config.toml when the executable starts (also added some functions that will make it easier to add/edit message responses on the fly)