### PR TITLE
Separate response config

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,11 @@ An example `config.toml` file looks like this:
 ```toml
 text_detect_cooldown = 5
 discord_token = "your_token_here"
-
-[[responses]]
-[responses.Text]
-name = "example"
-pattern = "ex(ample)?"
-content = "Hello, world!"
 ```
 Note that the text detection cooldown is
 specified in minutes.
 
-Message responses are also specified in the configuration file,
+Message responses are specified in the `assets/responses.toml` file,
 in a `[[responses]]` array. The four possible types of response
 are currently `Text`, `RandomText`, `Image`, and `TextAndImage`.
 Fields that are common to all response types are the `name` and `pattern`

--- a/assets/responses.toml
+++ b/assets/responses.toml
@@ -1,5 +1,4 @@
 [[responses]]
-
 [responses.RandomText]
 name = "rust"
 pattern = "rust"
@@ -17,7 +16,6 @@ content = [
 ]
 
 [[responses]]
-
 [responses.TextAndImage]
 name = "tkinter"
 pattern = "tkinter"
@@ -25,14 +23,12 @@ content = "TKINTER MENTIONED"
 path = "./assets/tkinter.png"
 
 [[responses]]
-
 [responses.Text]
 name = "arch"
 pattern = "arch"
 content = "I use Arch btw."
 
 [[responses]]
-
 [responses.RandomText]
 name = "goop"
 pattern = "goop"
@@ -42,14 +38,12 @@ content = [
 ]
 
 [[responses]]
-
 [responses.Text]
 name = "1984"
 pattern = "1984"
 content = "https://tenor.com/view/1984-gif-19260546"
 
 [[responses]]
-
 [responses.Text]
 name = "cs major"
 pattern = 'cs\s*major'

--- a/assets/responses.toml
+++ b/assets/responses.toml
@@ -1,0 +1,56 @@
+[[responses]]
+
+[responses.RandomText]
+name = "rust"
+pattern = "rust"
+content = [
+    "RUST MENTIONED :crab: :crab: :crab:",
+    "<@216767618923757568>",
+    "Rust is simply the best programming language. Nothing else can compare. I am naming my kids Rust and Ferris.",
+    """
+    Launch the Polaris,
+    the end doesn't scare us
+    When will this cease?
+    The warheads will all rust in peace
+    """,
+    "Rust? Oh, you mean the game?"
+]
+
+[[responses]]
+
+[responses.TextAndImage]
+name = "tkinter"
+pattern = "tkinter"
+content = "TKINTER MENTIONED"
+path = "./assets/tkinter.png"
+
+[[responses]]
+
+[responses.Text]
+name = "arch"
+pattern = "arch"
+content = "I use Arch btw."
+
+[[responses]]
+
+[responses.RandomText]
+name = "goop"
+pattern = "goop"
+content = [
+    "https://tenor.com/view/gunge-gunged-slime-slimed-dunk-gif-21115557",
+    "https://tenor.com/view/goop-goop-house-jello-gif-23114313"
+]
+
+[[responses]]
+
+[responses.Text]
+name = "1984"
+pattern = "1984"
+content = "https://tenor.com/view/1984-gif-19260546"
+
+[[responses]]
+
+[responses.Text]
+name = "cs major"
+pattern = 'cs\s*major'
+content = "I don't get the way you guys think. I want MONEY. 6 figures out of college. 200k a year entry level. I'm in this for MONEY. I don't care about whether I'm \"fulfilled\" I want MONEY. Whatever gets me the most MONEY. What technology gets me PAID THE BEST. All I care about in this major is MONEY. That's why I'm in college, I don't wanna laugh and play with y'all. I don't wanna be buddy buddy with y'all. I'm here for MONEY."

--- a/src/config.rs
+++ b/src/config.rs
@@ -59,26 +59,6 @@ impl Config {
         self.save();
     }
 
-    /// Adds a response to the config.toml file and the config.
-    pub fn add_response(&self, response: MessageResponse) {
-        let mut responses = self.responses.lock().unwrap();
-        responses.push(response);
-
-        self.save();
-    }
-
-    /// Removes a response from the config.toml file and the config.
-    pub fn remove_response(&self, name: String) {
-        let mut responses = self.responses.lock().unwrap();
-        *responses = responses
-            .iter()
-            .filter(|response| response.get_name() != name)
-            .cloned()
-            .collect();
-
-        self.save();
-    }
-
     /// Locks and returns the text detect cooldown.
     /// The mutex guard returned is guaranteed to be unlocked, so can be used immediately.
     pub fn lock_cooldown(&self) -> MutexGuard<Duration> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,7 +38,7 @@ impl Config {
     fn read_all_configs() -> String {
         let config = std::fs::read_to_string("./config.toml").expect("Error reading config.toml");
         let responses = std::fs::read_to_string("./assets/responses.toml").expect("Error reading responses.toml");;
-        return dbg!(config + "\n" + &responses);
+        return config + "\n" + &responses
     }
 
     /// Reloads the config.toml file and updates the configuration.

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,7 +40,7 @@ impl Config {
         let config = std::fs::read_to_string("./config.toml").expect("Error reading config.toml");
         let responses = std::fs::read_to_string("./assets/responses.toml")
             .expect("Error reading responses.toml");
-        return config + "\n" + &responses;
+        config + "\n" + &responses
     }
 
     /// Reloads the config.toml file and updates the configuration.
@@ -98,7 +98,7 @@ impl Config {
             discord_token: Some(self.discord_token.clone()),
             responses: self.responses.lock().unwrap().clone(),
         };
-        let mut toml = toml::to_string(&config_builder).unwrap();
+        let toml = toml::to_string(&config_builder).unwrap();
 
         let secrets = toml.split("[[responses]]").next().unwrap().to_string();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,7 +18,8 @@ impl Config {
     /// If the delay is missing, it will default to 5 minutes.
     /// If the discord token is missing, it will attempt to use the DISCORD_TOKEN environment variable.
     pub fn fetch() -> Config {
-        let config_builder: ConfigBuilder = toml::from_str(&Config::read_all_configs()).expect("Error parsing configuration.");
+        let config_builder: ConfigBuilder =
+            toml::from_str(&Config::read_all_configs()).expect("Error parsing configuration.");
         let text_detect_cooldown = match config_builder.text_detect_cooldown {
             Some(cooldown) => Duration::minutes(cooldown),
             None => Duration::minutes(DEFAULT_TEXT_DETECT_COOLDOWN),
@@ -37,8 +38,9 @@ impl Config {
 
     fn read_all_configs() -> String {
         let config = std::fs::read_to_string("./config.toml").expect("Error reading config.toml");
-        let responses = std::fs::read_to_string("./assets/responses.toml").expect("Error reading responses.toml");;
-        return config + "\n" + &responses
+        let responses = std::fs::read_to_string("./assets/responses.toml")
+            .expect("Error reading responses.toml");
+        return config + "\n" + &responses;
     }
 
     /// Reloads the config.toml file and updates the configuration.

--- a/src/text_detection.rs
+++ b/src/text_detection.rs
@@ -1,6 +1,6 @@
 use crate::types::{Data, Error};
 
-use std::sync::{MutexGuard};
+use std::sync::MutexGuard;
 
 use chrono::{DateTime, Duration, Utc};
 use poise::serenity_prelude as serenity;

--- a/src/types.rs
+++ b/src/types.rs
@@ -30,15 +30,6 @@ impl Data {
         }
     }
 
-    /// Register a new response type for messages matching a regular expression pattern
-    pub fn register(&self, response: MessageResponse) {
-        self.last_responses.lock().unwrap().insert(
-            response.get_name(),
-            DateTime::<Utc>::from_timestamp(0, 0).unwrap(),
-        );
-        self.config.add_response(response);
-    }
-
     /// Reload the configuration file and update the responses hash map accordingly
     pub fn reload(&self) {
         self.config.reload();

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,7 @@
 use crate::config::{Config, MessageResponse};
 
 use std::collections::HashMap;
-use std::sync::{Mutex};
+use std::sync::Mutex;
 
 use chrono::{DateTime, Utc};
 use poise::serenity_prelude as serenity;
@@ -58,11 +58,7 @@ impl Data {
     }
 
     pub fn last_response(&self, name: &String) -> DateTime<Utc> {
-        *self.last_responses
-            .lock()
-            .unwrap()
-            .get(name)
-            .unwrap()
+        *self.last_responses.lock().unwrap().get(name).unwrap()
     }
 
     pub fn reset_last_response(&self, name: &String, timestamp: DateTime<Utc>) {


### PR DESCRIPTION
By popular demand, I moved the responses to their own responses.toml file that is not in `.gitignore`. I also got rid of all the functions to add/remove responses on the fly (but left in the hot-reloading one) because that would get messy *quick*.