### PR TITLE
fixed cooldowns not being added during reload

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -171,7 +171,9 @@ mod test {
 
     #[test]
     fn should_deserialize_properly() {
-        let test_input = r#"[[responses]]
+        let test_input = r#"
+discord_token = "test_token_not_real"
+[[responses]]
 name = "1984"
 pattern = "1984"
 content = "literally 1984""#;

--- a/src/types.rs
+++ b/src/types.rs
@@ -35,8 +35,9 @@ impl Data {
     /// Reload the configuration file and update the responses hash map accordingly
     pub fn reload(&self) {
         self.config.reload();
-        self.last_responses
-            .alter_all(|_, _| DateTime::<Utc>::UNIX_EPOCH);
+        self.config.get_responses().iter().for_each(|response| {
+            self.reset_last_response(&response.name, DateTime::<Utc>::UNIX_EPOCH)
+        });
     }
 
     /// If the message contents match any pattern, return the name of the response type.


### PR DESCRIPTION
fixed a bug where response cooldowns wouldn't be added for new response types during `reload_config`, causing new responses to never work unless the program was stopped and started again.